### PR TITLE
Get usage status

### DIFF
--- a/src/main/java/org/dataone/bookkeeper/api/UsageStatus.java
+++ b/src/main/java/org/dataone/bookkeeper/api/UsageStatus.java
@@ -29,6 +29,7 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import java.io.IOException;
+import java.util.Objects;
 
 
 /**
@@ -38,7 +39,6 @@ import java.io.IOException;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class UsageStatus {
 
-
     /* The usagestatus object type */
     @NotEmpty
     @NotNull
@@ -46,16 +46,15 @@ public class UsageStatus {
     private String object;
 
     /*  The status of the quota usage, either active or inactive */
+    @NotEmpty
+    @NotNull
     @Pattern(regexp = "active|inactive")
     private String status;
-
 
     /**
      * A UsageStatus represents the active or inactive status of a Usage object as a light weight response
      */
-    public UsageStatus() {
-        super();
-    }
+    public UsageStatus() {}
 
     /**
      * Construct a UsageStatus from a JSON string
@@ -63,7 +62,6 @@ public class UsageStatus {
      * @throws IOException when an I/O exception occurs
      */
     public UsageStatus(String json) throws IOException {
-        super();
 
         // Return an empty Quota instance when the JSON object is empty
         if ( ! json.equals("{}") ) {
@@ -79,7 +77,7 @@ public class UsageStatus {
      * Construct a Usage instance
      * @param status  the usage status, either active or inactive
      */
-    public UsageStatus(@NotNull @NotEmpty String object,
+    public UsageStatus(@NotNull @NotEmpty @Pattern(regexp = "usagestatus") String object,
                        @NotNull @NotEmpty String status ) {
         this.object = object;
         this.status = status;
@@ -93,9 +91,9 @@ public class UsageStatus {
 
     /**
      * Set the usage object type
-     * @param status the usage object type, always 'usagestatus'
+     * @param object the usage object type, always 'usagestatus'
      */
-    public void setObject(String status) { this.status = status; }
+    public void setObject(String object) { this.object = object; }
 
     /**
      * Get the usage status
@@ -111,5 +109,28 @@ public class UsageStatus {
      */
     public void setStatus(String status) {
         this.status = status;
+    }
+
+    /**
+     * Determine object equality based on the equality of all fields
+     * @param o the object to be compared
+     * @return  true if the given object is equal
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UsageStatus usagestatus = (UsageStatus) o;
+        return Objects.equals(getObject(), usagestatus.getObject()) &&
+                Objects.equals(getStatus(), usagestatus.getStatus());
+    }
+
+    /**
+     * Calculate a hash based on all fields
+     * @return hashcode  the hashcode of the object
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(getObject(), getStatus());
     }
 }

--- a/src/test/java/org/dataone/bookkeeper/api/UsageStatusTest.java
+++ b/src/test/java/org/dataone/bookkeeper/api/UsageStatusTest.java
@@ -1,0 +1,77 @@
+/*
+ * This work was created by participants in the DataONE project, and is
+ * jointly copyrighted by participating institutions in DataONE. For
+ * more information on DataONE, see our web site at http://dataone.org.
+ *
+ *   Copyright 2029
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.dataone.bookkeeper.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jackson.Jackson;
+import org.junit.Ignore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.dropwizard.testing.FixtureHelpers.fixture;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test the usagestatus model
+ */
+class UsageStatusTest {
+    private final static ObjectMapper MAPPER = Jackson.newObjectMapper();
+    static {
+        MAPPER.setSerializationInclusion(Include.NON_NULL);
+        MAPPER.setSerializationInclusion(Include.NON_EMPTY);
+    }
+    private final static String USAGESTATUS_JSON = "fixtures/usagestatus.json";
+    private final static String OBJECT = "usagestatus";
+    private static final String STATUS = "active";
+
+
+    /**
+     * Test serialization to JSON
+     */
+    @Test
+    @Ignore
+    @DisplayName("Test UsageStatus model serialization")
+    public void serializesToJSON() throws Exception {
+        // Build the UsageStatus instance
+        final UsageStatus usagestatus = new UsageStatus(OBJECT, STATUS);
+        // Test the UsageStatus instance
+        final String expected = MAPPER.writeValueAsString(
+                MAPPER.readValue(fixture(USAGESTATUS_JSON), UsageStatus.class));
+        assertThat(MAPPER.writeValueAsString(usagestatus)).isEqualTo(expected);
+    }
+
+    /**
+     * Test deserialization from JSON
+     */
+    @Test
+    @Ignore
+    @DisplayName("Test UsageStatus model deserialization")
+    public void deserializesFromJSON() throws Exception {
+        // Build the UsageStatus instance
+        final UsageStatus usagestatus = new UsageStatus(OBJECT, STATUS);
+        // Test the UsageStatus instance
+        final UsageStatus deserializedUsageStatus =
+                MAPPER.readValue(fixture(USAGESTATUS_JSON), UsageStatus.class);
+        assertThat(deserializedUsageStatus).isEqualTo(usagestatus);
+    }
+}

--- a/src/test/resources/fixtures/usagestatus.json
+++ b/src/test/resources/fixtures/usagestatus.json
@@ -1,0 +1,4 @@
+{
+  "object" : "usagestatus",
+  "status" : "active"
+}


### PR DESCRIPTION
This PR resolves issue #55:
- add a UsageStatusTest 
  - commit 50a8dabf7f0980562b56ce58d7cc32a478edaf17
  - commit a488674a4a489219b754c1c874b7d29e8d6de3b8
- fix a UsageStatus.setObject error
  - commit a488674a4a489219b754c1c874b7d29e8d6de3b8

These changes have been checked locally with MetaDIG engine, which is now using `getUsageStatus` to determine
if a portal is active or not (tested via local bookkeeper instance).